### PR TITLE
Updated dependecies so gem build would stop complaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 .DS_Store
+*.gem

--- a/mitlibraries-theme.gemspec
+++ b/mitlibraries-theme.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_dependency 'rails'
-  spec.add_dependency 'sass'
-  spec.add_dependency 'sass-rails'
+  spec.add_dependency 'rails', '~> 5'
+  spec.add_dependency 'sass', '~> 3.4'
+  spec.add_dependency 'sass-rails', '~> 5'
 end


### PR DESCRIPTION
This prevents warnings like below during builds:

```
WARNING:  open-ended dependency on rails (>= 0) is not recommended
  if rails is semantically versioned, use:
    add_runtime_dependency 'rails', '~> 0'
WARNING:  open-ended dependency on sass (>= 0) is not recommended
  if sass is semantically versioned, use:
    add_runtime_dependency 'sass', '~> 0'
WARNING:  open-ended dependency on sass-rails (>= 0) is not recommended
  if sass-rails is semantically versioned, use:
    add_runtime_dependency 'sass-rails', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: mitlibraries-theme
  Version: 0.1.0
  File: mitlibraries-theme-0.1.0.gem
```