### PR TITLE
Replace Google Analytics with Matomo

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -25,26 +25,20 @@
 
 <%= yield :additional_js %>
 
-<% if (ENV['GOOGLE_ANALYTICS']) %>
+<% if (ENV['MATOMO_URL'].present? && ENV['MATOMO_SITE_ID'].present?) %>
+<!-- Matomo -->
 <script type="text/javascript">
-  // Google Analytics
-
-  (function(i,s,o,g,r,a,m){
-    i['GoogleAnalyticsObject']=r;
-    i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)
-    };
-    i[r].l=1*new Date();
-    a=s.createElement(o);
-    m=s.getElementsByTagName(o)[0];
-    a.async=1;
-    a.src=g;
-    m.parentNode.insertBefore(a,m);
-
-  }(window,document,'script','https://www.google-analytics.com/analytics.js','ga'));
-
-  ga('create', '<%= ENV['GOOGLE_ANALYTICS'] %>', 'auto');
-  ga('send', 'pageview');
-
+  var _paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u='<%= ENV['MATOMO_URL'] %>';
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '<%= ENV['MATOMO_SITE_ID'] %>']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
 </script>
+<!-- End Matomo Code -->
 <% end %>

--- a/lib/mitlibraries/theme/version.rb
+++ b/lib/mitlibraries/theme/version.rb
@@ -1,5 +1,5 @@
 module Mitlibraries
   module Theme
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end


### PR DESCRIPTION
This PR removes the Google Analytics tracking script with the Matomo tracking script. Because not all of our Rails apps will use Matomo at first, it loads the tracking code only if the requisite environmental variables are present:

`MATOMO_SITE_ID`: the ID in Matomo for the site to be tracked
`MATOMO_URL`: the URL of the site to be tracked