### PR TITLE
Updates javascript sentry for all apps using theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,27 @@ gem 'mitlibraries-theme'
 
 And then execute:
 
-    $ bundle
+```shell
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install mitlibraries-theme
+```shell
+$ gem install mitlibraries-theme
+```
 
 ## Usage
 
 After you bundle, delete your application local `app/views/layouts/application.rb` to use the layout the gem provides.
 
 Rename your `app/assets/stylesheets/application.css` to `app/assets/stylesheets/application.scss` and remove anything like:
-```
+
+```ruby
 *= require_tree .
 *= require_self
 ```
+
 Add
 `@import "libraries-main";`
 
@@ -46,7 +52,7 @@ If you need to make changes to other templates, you can also copy those to your 
 
 You can load additional js to individual pages using:
 
-```
+```ruby
 <% content_for :additional_js do %>
   <script>alert("hi");</script>
 <% end %>
@@ -61,7 +67,7 @@ for adding external support libraries. For JS you are writing, include via
 
 You can load additional meta headers to individual pages using:
 
-```
+```ruby
 <% content_for :additional_meta_tag do %>
   <meta name="description" content="Words and stuff about stuff or something.">
   <meta name="keywords" content="words,stuff,yoyos">
@@ -81,6 +87,7 @@ Run `make help` for details.
 
 If your goal is to fetch the latest assets from the style repo and publish the
 changes, this would get you there:
+
 - `make update`
 - manually update the version in `lib/mitlibraries/theme/version.rb`
 - `make dist`

--- a/app/views/layouts/_js_exception_handler.erb
+++ b/app/views/layouts/_js_exception_handler.erb
@@ -1,4 +1,14 @@
 <% if ENV['JS_EXCEPTION_LOGGER_KEY'].present? %>
-  <script src="https://cdn.ravenjs.com/3.25.2/raven.min.js" crossorigin="anonymous"></script>
-  <script>Raven.config('<%= ENV['JS_EXCEPTION_LOGGER_KEY'] %>').install()</script>
+  <script
+    src="https://browser.sentry-cdn.com/6.13.3/bundle.min.js"
+    integrity="sha384-sGMbmxgVprpEFMz6afNDyADd4Kav86v5Tvo2Y6w5t8tHUn1P1at3lCjN7IQo2c7E"
+    crossorigin="anonymous"
+  ></script>
+
+  <script>
+    Sentry.init({
+      dsn: <%= ENV['JS_EXCEPTION_LOGGER_KEY'] %>,
+      maxBreadcrumbs: 50,
+    });
+  </script>
 <% end %>

--- a/lib/mitlibraries/theme/version.rb
+++ b/lib/mitlibraries/theme/version.rb
@@ -1,5 +1,5 @@
 module Mitlibraries
   module Theme
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* The raven version of sentry has been deprecated for quite some time
* This is a drop in replacement for most of our apps as they don't
  do explicit configurations
* Th.Ing does have a Raven configuration and will need to change that
  to Sentry before upgrading to this theme (the PR that changes that app
  to use this new theme version will need to handle that at the same
  time)

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ENGX-88

NOTE: this only updates the JS component of Sentry. Apps should also change from Raven to Sentry gems but one does not require the other so the ordering is not critical.