### PR TITLE
Remove alt attribute from anchor in footer

### DIFF
--- a/app/views/layouts/_libraries_footer.html.erb
+++ b/app/views/layouts/_libraries_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="footer-main" aria-label="MIT Libraries footer">
       <div class="identity">
         <div class="wrap-logo-lib">
-          <a href="https://libraries.mit.edu" class="logo-mit-lib" alt="MIT Libraries Logo">
+          <a href="https://libraries.mit.edu" class="logo-mit-lib">
             <span class="sr">MIT Libraries home</span>
             <%= image_tag("mitlib-wordmark.svg", :alt => "MIT Libraries logo") %>
           </a>


### PR DESCRIPTION
#### Why are these changes being introduced:

* This attribute has been flagged by ANDI throughout our identity, and
  it isn't needed - there is a screen-reader accessible text for this
  SVG image, as well as a title attribute in the SVG itself.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/engx-67

#### How does this address that need:

* This removes the alt attribute

#### Document any side effects to this change:

* None