### PR TITLE
Bumps theme version to 0.8

### DIFF
--- a/lib/mitlibraries/theme/version.rb
+++ b/lib/mitlibraries/theme/version.rb
@@ -1,5 +1,5 @@
 module Mitlibraries
   module Theme
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end


### PR DESCRIPTION
#### Why are these changes being introduced:

* I missed that I still needed to bump the theme version with the recent
  a11y fix, so left it off of the PR.

#### Relevant ticket(s):

* n/a

#### How does this address that need:

* Bumps the theme version to 0.8

#### Document any side effects to this change:

* n/a