### PR TITLE
Remove boilerplate allowed_push_host restriction

### DIFF
--- a/mitlibraries-theme.gemspec
+++ b/mitlibraries-theme.gemspec
@@ -9,10 +9,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/MITLibraries/mitlibraries-theme'
   spec.license       = 'MIT'
   
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the "allowed_push_host"
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/MITLibraries/mitlibraries-theme"
   spec.metadata["changelog_uri"] = "https://github.com/MITLibraries/mitlibraries-theme/releases"


### PR DESCRIPTION
** Why are these changes being introduced:

* There is a boilerplate line in the gemspec file to restrict which sites can have releases pushed to them. We have not had this line in the past, and its presence appears to be part of the initial protections that need to be edited or removed.

** Relevant ticket(s):

* n/a

** How does this address that need:

* After considering whether to update this directive, or remove it entirely, it seems consistent with past practice to remove it entirely so this is what this PR does.

** Document any side effects to this change:

* None (we are free to consider implementing a real value for this, and reintroducing the directive, in a future ticket)

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
