### PR TITLE
Allow for optional platform names in header

### DIFF
--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -7,6 +7,9 @@
             <span class="sr">MIT Libraries home</span>
             <img src="https://cdn.libraries.mit.edu/files/branding/local/mitlib-wordmark.svg" height="35" alt="MIT Libraries logo">
           </a>
+          <% if ENV['PLATFORM_NAME'] %>
+            <a href="/" class="platform-name"><%= ENV.fetch('PLATFORM_NAME') %></a>
+          <% end %>
         </h1>
       </div>
       <div class="wrap-header-supp">

--- a/vendor/assets/stylesheets/elements/_header.scss
+++ b/vendor/assets/stylesheets/elements/_header.scss
@@ -40,6 +40,21 @@
     }
   }
 
+  .platform-name {
+    color: #fff;
+    font-size: 2.8rem;
+    text-decoration: none;
+    vertical-align: middle;
+    border-left: 1px solid #fff;
+    padding-left: 2rem;
+    margin-left: 2rem;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
   .link-logo-mit {
     color: $white;
 
@@ -50,6 +65,21 @@
         fill: $white;
       }
     }
+  }
+}
+
+@media (max-width: $bp-screen-md) {
+  .wrap-header {
+    .platform-name {
+      border-left: none;
+      padding: 0;
+      margin: 2rem 0 0 0;
+      display: block;
+    }
+  }
+  
+  .wrap-header-supp {
+    vertical-align: top;
   }
 }
 


### PR DESCRIPTION
#### Why these changes are being introduced:

Matt added the platform name to Omeka to remind users where in the MITL ecosystem they are. We were planning to add this to Geodata when we realized that it would probably be useful in other Rails apps, and should thus go in the theme gem.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-124

#### How this addresses that need:

This adds an optional platform name in the header, based on the `PLATFORM_NAME` environment variable. Environments that don't set `PLATFORM_NAME` will continue to have the standard header.

#### Side effects of this change:

The SCSS updates for this should likely be moved upstream to the style guide, but I couldn't decide if that should happen before or after this merges.

#### Developer

- [ ] All new ENV is documented in README **(Note: This will need to be done for each individual Rails app. I will open PRs to that effect one this merges.)**
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod **(Note: This will need to happen in each Heroku environment where we want this change applied.)**
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
