### PR TITLE
Display title in nav only if PLATFORM_NAME is not set

### DIFF
--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -1,8 +1,10 @@
 <div class="wrap-outer-header-local layout-band">
   <div class="wrap-header-local">
-    <div class="local-identity">
-      <h2 class="title title-site"><a href="/">Site Title</a></h2>
-    </div>
+    <%= unless ENV['PLATFORM_NAME'] %>
+      <div class="local-identity">
+        <h2 class="title title-site"><a href="/">Site Title</a></h2>
+      </div>
+    <% end %>
     <div class="wrap-local-nav">
       <div class="wrap-bar">
         <nav class="local-nav" aria-label="Main menu">


### PR DESCRIPTION
#### Why these changes are being introduced:

The app name is inserted into the header based on the `PLATFORM_NAME` environment variable. If this variable is set, the title should not display

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-124

#### How this addresses that need:

This makes the title in the nav render if `PLATFORM_NAME` is not set.

#### Side effects of this change:

We will need to make this change downstream, as most (if not all) of our Rails properties have customized the site nav partial.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
