### PR TITLE
Add integrity hashes for remote scripts and stylesheets

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,8 +7,8 @@
 
 <%= yield :additional_meta_tag %>
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css">
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" type="text/css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.1.1/normalize.min.css" integrity="sha512-4oJiHyX3IWAdU3YotQW0piF3VIAU+vzoBYFoBj8fEzqXK9e9N3GUUvgRAgrQxDmtWnbwzZ27BD85R7oQEag55Q==" crossorigin="anonymous" referrerpolicy="no-referrer">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic&subset=latin,latin-ext" integrity="sha512-bbxuNDhTy0hsTCnMdxZhzV9XM4aycXp/lSfDCW+VjsQehtF0G0laDWagWm4uPBNC4OD2Lf4cF4zeeCbORQaCQw==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <%= stylesheet_link_tag "application", :media => "all" %>
 
 <link rel="icon" href="https://cdn.libraries.mit.edu/files/branding/favicons/favicon.ico" sizes="32x32">
@@ -19,7 +19,7 @@
 <%= render partial: "layouts/js_exception_handler" %>
 <%= javascript_include_tag "application" %>
 
-<script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js'></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" integrity="sha512-3n19xznO0ubPpSwYCRRBgHh63DrV+bdZfHK52b1esvId4GsfwStQNPJFjeQos2h3JwCmZl0/LgLxSKMAI55hgw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
 <%= yield :additional_js %>
 


### PR DESCRIPTION
#### Why these changes are being introduced:

It's good practice to validate checksums for external libraries. We've done this in individual apps, but it makes sense to make the change in the theme gem.

#### Relevant ticket(s):

* [ENGX-290](https://mitlibraries.atlassian.net/browse/ENGX-290)

#### How this addresses that need:

This adds `integrity`, `crossorigin`, and `referrerpolicy` attributes for remotely hosted scripts and stylesheets.

#### Side effects of this change:

I'm not totally sure how to exhaustively test these changes. I've confirmed that the scripts/stylesheets load as expected, and checked the changes locally in a few of our apps. That feels like enough, but just signaling the uncertainty here in case the reviewer has additional insight.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO


[ENGX-290]: https://mitlibraries.atlassian.net/browse/ENGX-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ